### PR TITLE
Handle case where access token is not provided

### DIFF
--- a/api/WebForumApi.Test/Domain/Security/SessionManagerData.cs
+++ b/api/WebForumApi.Test/Domain/Security/SessionManagerData.cs
@@ -7,10 +7,16 @@ public sealed class SessionManagerData
     [ Guid.NewGuid() ]
   ];
 
-  public static IEnumerable<object[]> ScenarioForbidden =>
+  public static IEnumerable<object[]> ScenarioUnauthorizedCache =>
   [
     [ null ],
     [ 1 ],
     [ Guid.Empty]
+  ];
+
+  public static IEnumerable<object[]> ScenarioUnauthorizedMissingToken =>
+  [
+    [ null ],
+    [ string.Empty ]
   ];
 }

--- a/api/WebForumApi.Test/Domain/Security/SessionManagerTests.cs
+++ b/api/WebForumApi.Test/Domain/Security/SessionManagerTests.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 using WebForumApi.Domain;
@@ -41,12 +40,14 @@ public sealed class SessionManagerTests
 
   [Theory]
   [MemberData(
-    nameof(SessionManagerData.ScenarioForbidden),
+    nameof(SessionManagerData.ScenarioUnauthorizedCache),
     MemberType = typeof(SessionManagerData))]
-  public void GetCachedUser_Forbidden(
+  public void GetCachedUser_Unauthorized_When_Missing_Or_Invalid_Cache(
     object cacheValue
   )
   {
+    var token = "token";
+
     cache
       .TryGetValue(Arg.Any<string>(), out Arg.Any<Object>())
       .Returns(call =>
@@ -55,6 +56,19 @@ public sealed class SessionManagerTests
         return true;
       });
 
-    Assert.Throws<SecurityException>(() => sessionManager.GetCachedUser(Arg.Any<string>()));
+    Assert.Throws<UnauthorizedAccessException>(()
+      => sessionManager.GetCachedUser(token));
+  }
+
+  [Theory]
+  [MemberData(
+    nameof(SessionManagerData.ScenarioUnauthorizedMissingToken),
+    MemberType = typeof(SessionManagerData))]
+  public void GetCachedUser_Unauthorized_When_Token_Missing(
+    string token
+  )
+  {
+    Assert.Throws<UnauthorizedAccessException>(()
+      => sessionManager.GetCachedUser(token));
   }
 }

--- a/api/WebForumApi/Domain/Constants/Messages.cs
+++ b/api/WebForumApi/Domain/Constants/Messages.cs
@@ -3,5 +3,6 @@ namespace WebForumApi.Domain;
 public static class Messages
 {
   public const string UnauthorizedAccess = "You are unauthorized to access this resource. Please check your username or password.";
+  public const string MissingAccessToken = "You are unauthorized to access this resource. Please include access token.";
   public const string ForbiddenError = "You are unauthorized to access this resource. Please check you privileges.";
 }

--- a/api/WebForumApi/Domain/Security/SessionManager.cs
+++ b/api/WebForumApi/Domain/Security/SessionManager.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace WebForumApi.Domain;
@@ -10,12 +9,13 @@ public sealed class SessionManager(
 {
   public Guid GetCachedUser(string token)
   {
+    if (string.IsNullOrWhiteSpace(token))
+      throw new UnauthorizedAccessException(Messages.MissingAccessToken);
+
     var cacheValue = cache.Get(token);
 
     if (!Guid.TryParse(cacheValue?.ToString(), out var userGuid) || userGuid == Guid.Empty)
-    {
-      throw new SecurityException(Messages.ForbiddenError);
-    }
+      throw new UnauthorizedAccessException(Messages.UnauthorizedAccess);
 
     return userGuid;
   }


### PR DESCRIPTION
- Fixed issue where not providing `X-Access-Token` results in error 400.
- Fixed issue where token not available on cache results in error 403.
- Each of these scenarios should return 401 instead.